### PR TITLE
Moved meeples in 3-side cities to the tile edge

### DIFF
--- a/pkg/board/feature/factory/city_samples.go
+++ b/pkg/board/feature/factory/city_samples.go
@@ -206,7 +206,7 @@ func LeftTopRightCity(f elements.PlacedFeature) feature.Feature {
 		cityFeature.AddModifier(Shield(rl.NewVector2(50, 5)))
 	}
 	if hasMeeple(f) {
-		cityFeature.AddMeeple(rl.NewVector2(30, 30), f.Meeple.PlayerID)
+		cityFeature.AddMeeple(rl.NewVector2(30, meeple.RadiusWithMargin), f.Meeple.PlayerID)
 	}
 
 	return cityFeature
@@ -224,7 +224,7 @@ func TopRightBottomCity(f elements.PlacedFeature) feature.Feature {
 		cityFeature.AddModifier(Shield(rl.NewVector2(50, 5)))
 	}
 	if hasMeeple(f) {
-		cityFeature.AddMeeple(rl.NewVector2(30, 30), f.Meeple.PlayerID)
+		cityFeature.AddMeeple(rl.NewVector2(60-meeple.RadiusWithMargin, 30), f.Meeple.PlayerID)
 	}
 
 	return cityFeature
@@ -242,7 +242,7 @@ func RightBottomLeftCity(f elements.PlacedFeature) feature.Feature {
 		cityFeature.AddModifier(Shield(rl.NewVector2(50, 50)))
 	}
 	if hasMeeple(f) {
-		cityFeature.AddMeeple(rl.NewVector2(30, 30), f.Meeple.PlayerID)
+		cityFeature.AddMeeple(rl.NewVector2(30, 60-meeple.RadiusWithMargin), f.Meeple.PlayerID)
 	}
 
 	return cityFeature
@@ -260,7 +260,7 @@ func BottomLeftTopCity(f elements.PlacedFeature) feature.Feature {
 		cityFeature.AddModifier(Shield(rl.NewVector2(10, 5)))
 	}
 	if hasMeeple(f) {
-		cityFeature.AddMeeple(rl.NewVector2(30, 30), f.Meeple.PlayerID)
+		cityFeature.AddMeeple(rl.NewVector2(meeple.RadiusWithMargin, 30), f.Meeple.PlayerID)
 	}
 
 	return cityFeature


### PR DESCRIPTION
Before it was not obvious if the meeple is on a road or in the city.

Before:
![image](https://github.com/user-attachments/assets/6bdc1bed-1c75-4990-a5d4-272c820b21cc)

After:
![image](https://github.com/user-attachments/assets/0a3e8a02-6bad-43ed-8247-66259bff1722)

Log file: 
[log.json](https://github.com/user-attachments/files/17326251/log.json)
